### PR TITLE
Fixes for using TraitInterfaces within ACSets.jl

### DIFF
--- a/src/Implementations/Check.jl
+++ b/src/Implementations/Check.jl
@@ -6,7 +6,7 @@ module Check
 
 export implements, impl_type, impl_types
 
-using ...MetaUtils: fq_eval
+using ...MetaUtils: getpath
 using ...Interfaces
 import ...Interfaces.InterfaceModules: impl_type, implements
 
@@ -38,7 +38,7 @@ function implements(m, theory_module::Module, types = nothing)
     implements(m, theory_module, nameof(j), map(signature(j)) do arg 
       haskey(type_dict, arg) && return type_dict[arg]
       n = nameof(arg)
-      fq_eval([T.external[n]; n])
+      getpath(T.external[n][1], [T.external[n][2]; n])
     end)
   end
 end 

--- a/src/Implementations/ModelInterface.jl
+++ b/src/Implementations/ModelInterface.jl
@@ -103,7 +103,7 @@ macro instance(head, model, body)
   # A dictionary to look up the Julia type of a type constructor from its name (an ident)
   jltype_by_sort = Dict{AlgSort,Expr0}([
     zip(abs_sorts, instance_types)..., 
-    [AlgSort(s) => getpathexpr(theory.external[s]..., s)  
+    [AlgSort(s) => getpathexpr(path_diff(__module__,theory.external[s])..., s)  
      for s in nameof.(sorts(theory)) if haskey(theory.external,s)]...
   ]) 
 

--- a/src/Implementations/ModelInterface.jl
+++ b/src/Implementations/ModelInterface.jl
@@ -148,9 +148,12 @@ function get_judgment_runtime(instance_module,theory, f_name, args,
   end
   tcs = map(combos) do combo
     try lookup(theory, f_name, combo) catch e nothing end
-  end
+  end |> vec
   # TODO also potentially disambiguate using the return type.
-  only(filter(x->!isnothing(x), tcs))
+  filter!(x->!isnothing(x), tcs)
+  length(tcs) == 1 || error(
+    "Failed to find $f_name with args $args and $whereparams and $jltype_by_sort")
+  only(tcs)
 end
 
 

--- a/src/Interfaces/InterfaceData.jl
+++ b/src/Interfaces/InterfaceData.jl
@@ -25,7 +25,7 @@ to distinct abstract types can then cause method ambiguities.
   name::Symbol
   judgments::Vector{Judgment}
   aliases::Dict{Symbol, Symbol}
-  external::Dict{Symbol, Vector{Symbol}} # give a fully-qualified module name
+  external::Dict{Symbol, Pair{Module,Vector{Symbol}}} # give a fully-qualified module name
   defaults::Dict{Int, Expr}
 
   # cached data for easy access
@@ -73,7 +73,7 @@ end
 Base.getindex(f::Interface, i) = f.judgments[i]
 
 Base.copy(f::Interface) = Interface(f.name, deepcopy(f.judgments), 
-  copy(f.aliases), deepcopy(f.external), deepcopy(f.defaults), 
+  copy(f.aliases), copy(f.external), deepcopy(f.defaults), 
   copy(f.types), copy(f.ops), 
   copy(f.accessors), copy(f.axioms), deepcopy(f.lookup))
 

--- a/src/Interfaces/InterfaceModules.jl
+++ b/src/Interfaces/InterfaceModules.jl
@@ -260,7 +260,7 @@ function wrapper(name::Symbol, t::Interface, mod)
           j = $(t)[i]
           op = nameof(j)
           :(@inline function $($(name)).$op(x::$(($(:n))), args...; kw...) 
-              $($(name)).$op(Trait(x.val), args...; kw...)
+              $($(name)).$op($($(GlobalRef(InterfaceModules, :Trait)))(x.val), args...; kw...)
           end)
       end...)
 
@@ -332,9 +332,9 @@ function wrapper(name::Symbol, t::Interface, mod)
           j = $(t)[i]
           op = nameof(j)
           :(@inline function $($(name)).$op(x::$(($(:n))), args...; kw...) 
-              $($(name)).$op(Trait(x.val), args...; kw...)
+              $($(name)).$op($($(GlobalRef(InterfaceModules, :Trait)))(x.val), args...; kw...)
           end)
-        end)
+        end...)
 
       nothing
 

--- a/src/Interfaces/Syntax.jl
+++ b/src/Interfaces/Syntax.jl
@@ -1,6 +1,8 @@
 """ The building blocks that make up an interface """
 module Syntax 
 
+using MLStyle
+
 export AlgSort, AlgTerm, TermApp, TermVar, AlgType, TypeApp, VarArgType, 
        Judgment, TypeScope, Maybe,
        TypeConstructor, TermConstructor, AlgAxiom, AlgAccessor, signature,
@@ -27,6 +29,10 @@ A *sort*, which is essentially a type constructor without arguments
   AlgSort(m::Symbol, v::Bool=false) = new(m, v)
 end
 
+AlgSort(a::Expr, v::Bool=false) = @match a begin 
+  Expr(:curly, f, _...) => AlgSort(f, v)
+  _ => error("unexpected expression $a")
+end
 
 
 Base.nameof(s::AlgSort) = s.method

--- a/src/MetaUtils.jl
+++ b/src/MetaUtils.jl
@@ -185,20 +185,21 @@ function strip_lines(expr::Expr; recurse::Bool=false)::Expr
 end
 
 """ Fully Qualified Module Name """
-function fqmn(mod::Module)
+function fqmn(mod::Module)::Pair{Module, Vector{Symbol}}
   names = Symbol[]
   while parentmodule(mod) != mod
     push!(names, nameof(mod))
     mod = parentmodule(mod)
   end
   push!(names, nameof(mod))
-  reverse(names)
+  mod => reverse(names)[2:end]
 end
 
-""" 
-Evaluate an expression `A.B.C.Foo` by calling `eval` on `A` and then
-iteratively calling `getproperty`
-"""
-fq_eval(v::Vector{Symbol}) = foldl(getproperty, [eval(first(v)), v[2:end]...])
+# Modules
+##########
+getpath(m::Module, v::Vector{Symbol}) = foldl(getproperty, v; init=m)
+
+getpathexpr(m::Module, v::Vector{Symbol}, s::Symbol) = 
+  foldl((x,y)->Expr(:., x, QuoteNode(y)), [v; s]; init=nameof(m))
 
 end # module

--- a/test/TestImplementations.jl
+++ b/test/TestImplementations.jl
@@ -25,14 +25,20 @@ import .MyModule: SpecialType
 
 """ A reflexive graph """
 @interface ThReflGraphBool begin
+  # Demonstrating abstract types
   Ob::TYPE
 
+  # demonstrating concrete types
   @import Bool::TYPE
   @import SpecialType::TYPE
 
+  # Demonstrating abstract dependent types
   Hom(dom::Ob, codom::Ob)::TYPE
-  @op (→) := Hom # alias for Hom
 
+  # demonstrating Type aliases
+  @op (→) := Hom
+
+  # demonstrating operations
   id(A::Ob)::(A → A)
 end
 
@@ -40,15 +46,26 @@ end
 
 # Extending a theory
 @interface ThTest <: ThReflGraphBool begin
-  
+  # demonstrating operations which act on fixed, concrete types
   one(a::SpecialType)::Ob
+
+  # demonstrating operations on dependent types
   compose(f::(A → B), g::(B → C))::(A → C) ⊣ [A::Ob, B::Ob, C::Ob]
+  
+  # demonstrating operation aliases
   @op (⋅) := compose
 
+  # Demonstrating axioms
   f⋅id(B) == f ⊣ [A::Ob, B::Ob, f::(A → B)]
   id(A)⋅f == f ⊣ [A::Ob, B::Ob, f::(A → B)]
+  assoc := (f⋅g)⋅h == f⋅(g⋅h) ⊣ [
+    (A,B,C,D)::Ob, f::(A → B), g::(B → C), h::(C → D)]
 
-  assoc := (f⋅g)⋅h == f⋅(g⋅h) ⊣ [(A,B,C,D)::Ob, f::(A → B), g::(B → C), h::(C → D)]
+  # Demonstrating operations with default operations
+  one_or_ob(a::SpecialType, b::Ob)::Ob 
+  function one_or_ob(a::SpecialType, b::Ob)::Ob 
+    ThTest.one[model](a)
+  end
 end
 
 T = ThTest.Meta.theory;
@@ -129,9 +146,10 @@ end
 
 @test !implements(3, ThTest)
 
-@withmodel FinSetC() (⋅, id) begin
+@withmodel FinSetC() (⋅, id, one_or_ob) begin
   s21, s12 = SVector{2}.([[2,1],[1,2]])
   @test s21 ⋅ s21 ⋅ id(2) == s12
+  one_or_ob(SpecialType(), 5) == 1
 end
 
 # MatC
@@ -141,6 +159,8 @@ end
   compose(m::Matrix{T}, n::Matrix{T}) = m * n
   id(n::Int) = Matrix{T}(LinearAlgebra.I,n,n)
   one(::SpecialType) = 1
+  # override the default
+  one_or_ob(a::SpecialType, b::Int)::Int = b
 end
 
 # The implementation type can depend on type parameters of the model.
@@ -156,6 +176,9 @@ w = TestWrapper(MatC{Int}())
 
 x = TestTypedWrapper(MatC{Int}())
 @test x isa TestTypedWrapper{Int, Matrix{Int}}
+
+# test that default method was overwritten
+one_or_ob(w, SpecialType(), 4) == 4
 
 
 # Fixed methods

--- a/test/TestImplementations.jl
+++ b/test/TestImplementations.jl
@@ -137,7 +137,7 @@ end
 # MatC
 #-----
 
-@instance ThTest{Ob=Int, Hom=Matrix{T}} [model::MatC{T}] where T begin
+@instance ThTest{Ob=Int, Hom=Matrix{T}} [model::MatC{T}] where {T<:Number} begin
   compose(m::Matrix{T}, n::Matrix{T}) = m * n
   id(n::Int) = Matrix{T}(LinearAlgebra.I,n,n)
   one(::SpecialType) = 1


### PR DESCRIPTION
Various things break when TraitInterfaces is used within another library (as opposed to in the test module of TraitInterfaces itself), e.g. such as certain uses of `eval`, macros which refer to things exported by TraitInterfaces (which now must use `GlobalRef`). These cracks were revealed in the process of integrating ACSets.jl with TraitInterfaces.